### PR TITLE
[feature] Add LDAP Authentication with automatic registration

### DIFF
--- a/roles/foreman-idevfsd/tasks/foreman-config.yml
+++ b/roles/foreman-idevfsd/tasks/foreman-config.yml
@@ -9,6 +9,25 @@
       admin.save
     recheck: yes
 
+- name: "{{ foreman_ldap_name }} Authentication with automatic registration"
+  environment: "{{ foreman_api_environment }}"
+  theforeman.foreman.auth_source_ldap:
+    name: "{{ foreman_ldap_name }}"
+    host: "{{ foreman_ldap_host }}"
+    tls: "{{ foreman_ldap_tls }}"
+    port: "{{ foreman_ldap_port }}"
+    onthefly_register: true
+    base_dn: "{{ foreman_ldap_base_dn }}"
+    groups_base: "{{ foreman_ldap_auth_groups_base }}"
+    server_type: free_ipa
+    attr_login: uid
+    attr_firstname: givenName
+    attr_lastname: sn
+    attr_mail: mail
+    state: present
+  tags:
+    - foreman.config.ldap
+
 - name: "Connect to smart proxy"
   environment: "{{ foreman_api_environment }}"
   theforeman.foreman.smart_proxy:

--- a/roles/foreman-idevfsd/tasks/foreman-tasks.yml
+++ b/roles/foreman-idevfsd/tasks/foreman-tasks.yml
@@ -43,9 +43,11 @@
       tags:
         - foreman
         - foreman.config
+        - foreman.config.ldap
   tags:
     - foreman
     - foreman.config
+    - foreman.config.ldap
 
 - name: "Foreman configuration - Settings related to OSes and installation"
   include_tasks:

--- a/roles/foreman-idevfsd/vars/foreman-vars.yml
+++ b/roles/foreman-idevfsd/vars/foreman-vars.yml
@@ -68,6 +68,13 @@ foreman_api_environment:
 foreman_main_organization_name: IDEV-FSD
 foreman_main_location_name: XaaS Prod
 
+foreman_ldap_name: "EPFL LDAP"
+foreman_ldap_host: "ldap.epfl.ch"
+foreman_ldap_tls: true
+foreman_ldap_port: 636
+foreman_ldap_base_dn: "o=epfl,c=ch"
+foreman_ldap_auth_groups_base: "ou=idev-fsd,ou=idev,ou=vpo-si,o=epfl,c=ch"
+
 foreman_ptable_template_name: "IC-IT style preseed LVM partition table"
 
 foreman_kexec_template_name: "EPFL Debian kexec"


### PR DESCRIPTION
This uses the `theforeman.foreman.auth_source_ldap` Ansible module to 
configure the LDAP auth for foreman. LDAP's name, host, tls, port, 
base_dn and groups_base are managed as Ansible vars.